### PR TITLE
Allow object-formatted username/password parameter fields

### DIFF
--- a/lib/passport-local/strategy.js
+++ b/lib/passport-local/strategy.js
@@ -67,12 +67,12 @@ util.inherits(Strategy, passport.Strategy);
  * @api protected
  */
 Strategy.prototype.authenticate = function(req) {
-  if (!req.body || (!req.body[this._usernameField] || !req.body[this._passwordField])) {
+  var username = lookup(req.body, this._usernameField);
+  var password = lookup(req.body, this._passwordField);
+  
+  if (!req.body || !username || !password) {
     return this.fail(new BadRequestError('Missing credentials'));
   }
-  
-  var username = req.body[this._usernameField];
-  var password = req.body[this._passwordField];
   
   var self = this;
   
@@ -86,6 +86,18 @@ Strategy.prototype.authenticate = function(req) {
     this._verify(req, username, password, verified);
   } else {
     this._verify(username, password, verified);
+  }
+  
+  function lookup(obj, field) {
+    if (!obj) { return null; }
+    var elements = field.split(']').join('').split('[');
+    for (i = 0; i < elements.length; i++) {
+      var element = obj[elements[i]];
+      if (typeof(element) === 'undefined') { return null; }
+      if (typeof(element) !== 'object') { return element; }
+      obj = element;
+    }
+    return obj;
   }
 }
 


### PR DESCRIPTION
This resolves issue #9 in which object-formatted query string parameters were not able to be handled.
