### PR TITLE
Allow user/pass to be elsewhere than in the body

### DIFF
--- a/lib/passport-local/strategy.js
+++ b/lib/passport-local/strategy.js
@@ -67,12 +67,11 @@ util.inherits(Strategy, passport.Strategy);
  * @api protected
  */
 Strategy.prototype.authenticate = function(req) {
-  if (!req.body || (!req.body[this._usernameField] || !req.body[this._passwordField])) {
+  var username = req.param(this._usernameField);
+  var password = req.param(this._passwordField);
+  if (!username || !password) {
     return this.fail(new BadRequestError('Missing credentials'));
   }
-  
-  var username = req.body[this._usernameField];
-  var password = req.body[this._passwordField];
   
   var self = this;
   


### PR DESCRIPTION
Use req.param(), which will check route params, query and body.
