### PR TITLE
Update app.js to use express() 

### DIFF
--- a/examples/express3/app.js
+++ b/examples/express3/app.js
@@ -73,7 +73,7 @@ passport.use(new LocalStrategy(
 
 
 
-var app = express.createServer();
+var app = express();
 
 // configure Express
 app.configure(function() {


### PR DESCRIPTION
In express 3.x express.createServer() is depreciated.
