### PR TITLE
Support for array like values in `name` attributes

### DIFF
--- a/lib/passport-local/strategy.js
+++ b/lib/passport-local/strategy.js
@@ -91,7 +91,7 @@ Strategy.prototype.authenticate = function(req, options) {
     this._verify(username, password, verified);
   }
   
-  function lookup(obj, field) {
+  function lookup(obj, domain, field) {
     if (!obj) { return null; }
     var chain = field.split(']').join('').split('[');
     for (var i = 0, len = chain.length; i < len; i++) {


### PR DESCRIPTION
Support for attribute `name` with array like values.
example: 
`<input type="text" name="login[name]" id="name" />`

The variables could then be accessed using `req.body.login.name`
