### PR TITLE
add options.strategyName to allow multiple passport-local instances to work in one node.js app;

### DIFF
--- a/lib/passport-local/strategy.js
+++ b/lib/passport-local/strategy.js
@@ -23,6 +23,7 @@ var passport = require('passport')
  * Options:
  *   - `usernameField`  field name where the username is found, defaults to _username_
  *   - `passwordField`  field name where the password is found, defaults to _password_
+ *   - `strategyName`   custom strategy name for multiple uses, defaults to _local_
  *   - `passReqToCallback`  when `true`, `req` is the first argument to the verify callback (default: `false`)
  *
  * Examples:
@@ -50,7 +51,7 @@ function Strategy(options, verify) {
   this._passwordField = options.passwordField || 'password';
   
   passport.Strategy.call(this);
-  this.name = 'local';
+  this.name = options.strategyName || 'local';
   this._verify = verify;
   this._passReqToCallback = options.passReqToCallback;
 }

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -17,6 +17,20 @@ vows.describe('LocalStrategy').addBatch({
     },
   },
   
+  'multiple strategies': {
+    topic: function() {
+      return [
+        new LocalStrategy({ strategyName: 'local-one' }, function(){}),
+        new LocalStrategy({ strategyName: 'local-two' }, function(){})
+      ];
+    },
+    
+    'should be named session': function (strategies) {
+      assert.equal(strategies[0].name, 'local-one');
+      assert.equal(strategies[1].name, 'local-two');
+    },
+  },
+  
   'strategy handling a request': {
     topic: function() {
       var strategy = new LocalStrategy(function(){});


### PR DESCRIPTION
Example code:

```
// login for normal users:

passport.use(new LocalStrategy({ strategyName: 'local' }, ... );

app.post('/login', passport.authenticate('local', {
  successReturnToOrRedirect: '/',
  failureRedirect: '/login'
}));

app.get('/', function(req, res, next){
  if (req.user) {
    res.render('index');
  } else {
    res.redirect('/login');
  }
});


// login for admins:

passport.use(new LocalStrategy({ strategyName: 'local-admin' }, ... );

app.post('/admin/login', passport.authenticate('local-admin', {
  successReturnToOrRedirect: '/admin',
  failureRedirect: '/admin/login'
}));

app.get('/admin', function(req, res, next){
  if (req.user && req.user.is_admin) {
    res.render('admin/index');
  } else {
    res.redirect('/admin/login');
  }
});
```
