### PR TITLE
fixing bug where no flash messages would trigger

### DIFF
--- a/examples/express3/app.js
+++ b/examples/express3/app.js
@@ -84,11 +84,11 @@ app.configure(function() {
   app.use(express.bodyParser());
   app.use(express.methodOverride());
   app.use(express.session({ secret: 'keyboard cat' }));
-  app.use(flash());
   // Initialize Passport!  Also use passport.session() middleware, to support
   // persistent login sessions (recommended).
   app.use(passport.initialize());
   app.use(passport.session());
+  app.use(flash());
   app.use(app.router);
   app.use(express.static(__dirname + '/../../public'));
 });


### PR DESCRIPTION
updating example so that calling flash() should be performed only after passport.initialize and passport.session have been called.
