### PR TITLE
move passport to peerDependencies; fix specs by allowing newer vows

### DIFF
--- a/lib/passport-local/strategy.js
+++ b/lib/passport-local/strategy.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-var passport = require('passport')
+var passport = require('passport-strategy')
   , util = require('util')
   , BadRequestError = require('./errors/badrequesterror');
 

--- a/package.json
+++ b/package.json
@@ -21,10 +21,8 @@
   } ],
   "main": "./lib/passport-local",
   "dependencies": {
-    "pkginfo": "0.2.x"
-  },
-  "peerDependencies": {
-    "passport": ">=0.1.1 <1"
+    "pkginfo": "0.2.x",
+    "passport-strategy": "1.x.x"
   },
   "devDependencies": {
     "vows": "*"


### PR DESCRIPTION
I ran into two issues when bringing passport-local into my app.  This PR fixes both of them:
1. my app installed passport version 0.2.0, but passport-local was pegged at ~0.1.1, which meant passport did not work (long story short).  I believe the correct pattern here is to move passport to peerDependencies in the package.json file.  I did that, and also allowed for other minor versions within the 0 major version.
2. the specs were broken because vows was out of date.  seems safe to allow any version of vows given it's in devDependencies and only affects running the tests, so I did that.  specs run again!
