### PR TITLE
Update strategy to work with no field

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -53,6 +53,7 @@ function Strategy(options, verify) {
   this.name = 'local';
   this._verify = verify;
   this._passReqToCallback = options.passReqToCallback;
+  this._allowNoField = options.allowNoField || false;
 }
 
 /**
@@ -71,11 +72,13 @@ Strategy.prototype.authenticate = function(req, options) {
   var username = lookup(req.body, this._usernameField) || lookup(req.query, this._usernameField);
   var password = lookup(req.body, this._passwordField) || lookup(req.query, this._passwordField);
   
-  if (!username || !password) {
-    return this.fail({ message: options.badRequestMessage || 'Missing credentials' }, 400);
-  }
-  
   var self = this;
+  
+  if(!self._allowNoField) {
+    if (!username || !password) {
+      return this.fail({ message: options.badRequestMessage || 'Missing credentials' }, 400);
+    }
+  }
   
   function verified(err, user, info) {
     if (err) { return self.error(err); }


### PR DESCRIPTION
It could be very useful to have the option to permit send request with no body. For example, we can use an usual login strategy with username and password, OR a cookie-based login if username and password fields are not given. I tried myself and it was a success, we don't need to send a 400 status error because we can handle it further. 