### PR TITLE
Add options.params argument for non-Express environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: "node_js"
 node_js:
+  - "0.12"
   - "0.10"
   - "0.8"
-#  - "0.6"
-  - "0.4"
 
 before_install:
  - "npm install istanbul -g"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
   - "0.8"
 
 before_install:
+ - "if [[ $(node --version) =~ v0\\.8\\.* ]]; then npm install npm@1.2.x -g; fi" # Prevent bug on npm 1.2.30
+ - "npm --version"
  - "npm install istanbul -g"
  - "npm install coveralls -g"
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -64,6 +64,7 @@ util.inherits(Strategy, passport.Strategy);
  * Authenticate request based on the contents of a form submission.
  *
  * @param {Object} req
+ * @param {Object} options.badRequestMessage - Message to be shown when username and/or password is not given as parameter
  * @param {Object} options.params - Given GET/POST parameters object. On Express, you don't have to specify this because parameters are automatically analyzed from req.body or req.query.
  * @api protected
  */

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -64,12 +64,13 @@ util.inherits(Strategy, passport.Strategy);
  * Authenticate request based on the contents of a form submission.
  *
  * @param {Object} req
+ * @param {Object} options.params - Given GET/POST parameters object. On Express, you don't have to specify this because parameters are automatically analyzed from req.body or req.query.
  * @api protected
  */
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
-  var username = lookup(req.body, this._usernameField) || lookup(req.query, this._usernameField);
-  var password = lookup(req.body, this._passwordField) || lookup(req.query, this._passwordField);
+  var username = lookup(options.params, this._usernameField) || lookup(req.body, this._usernameField) || lookup(req.query, this._usernameField);
+  var password = lookup(options.params, this._passwordField) || lookup(req.body, this._passwordField) || lookup(req.query, this._passwordField);
 
   if (!username || !password) {
     return this.fail({ message: options.badRequestMessage || 'Missing credentials' }, 400);

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -45,10 +45,10 @@ function Strategy(options, verify) {
     options = {};
   }
   if (!verify) { throw new TypeError('LocalStrategy requires a verify callback'); }
-  
+
   this._usernameField = options.usernameField || 'username';
   this._passwordField = options.passwordField || 'password';
-  
+
   passport.Strategy.call(this);
   this.name = 'local';
   this._verify = verify;
@@ -70,19 +70,19 @@ Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var username = lookup(req.body, this._usernameField) || lookup(req.query, this._usernameField);
   var password = lookup(req.body, this._passwordField) || lookup(req.query, this._passwordField);
-  
+
   if (!username || !password) {
     return this.fail({ message: options.badRequestMessage || 'Missing credentials' }, 400);
   }
-  
+
   var self = this;
-  
+
   function verified(err, user, info) {
     if (err) { return self.error(err); }
     if (!user) { return self.fail(info); }
     self.success(user, info);
   }
-  
+
   try {
     if (self._passReqToCallback) {
       this._verify(req, username, password, verified);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chai-passport-strategy": "0.1.x"
   },
   "engines": {
-    "node": ">= 0.4.0"
+    "node": ">= 0.8"
   },
   "scripts": {
     "test": "node_modules/.bin/mocha --reporter spec --require test/bootstrap/node test/*.test.js"

--- a/test/strategy.options.test.js
+++ b/test/strategy.options.test.js
@@ -34,4 +34,34 @@ describe('Strategy', function() {
     });
   });
 
+  describe('handling an authentication request from non-Express framework: username and password parameters are given as optional arguments', function() {
+    var user
+    , info;
+
+    before(function(done) {
+      chai.passport(new Strategy({ passReqToCallback: true }, function(req, username, password, done) {
+        if (username === 'johndoe' && password === 'secret') {
+          return done(null, { id: '1234' }, { scope: 'read' });
+        }
+        return done(null, false);
+      }))
+        .success(function(u, i) {
+        user = u;
+        info = i;
+        done();
+      })
+        .authenticate({ params: { username: 'johndoe', password: 'secret' }});
+    });
+
+    it('should supply user', function() {
+      expect(user).to.be.an.object;
+      expect(user.id).to.equal('1234');
+    });
+
+    it('should supply info', function() {
+      expect(info).to.be.an.object;
+      expect(info.scope).to.equal('read');
+    });
+
+  });
 });

--- a/test/strategy.options.test.js
+++ b/test/strategy.options.test.js
@@ -6,14 +6,14 @@ var chai = require('chai')
 
 
 describe('Strategy', function() {
-    
+
   describe('handling a request without a body, but no username and password, with message option to authenticate', function() {
     var strategy = new Strategy(function(username, password, done) {
       throw new Error('should not be called');
     });
-    
+
     var info, status;
-    
+
     before(function(done) {
       chai.passport(strategy)
         .fail(function(i, s) {
@@ -26,12 +26,12 @@ describe('Strategy', function() {
         })
         .authenticate({ badRequestMessage: 'Something is wrong with this request' });
     });
-    
+
     it('should fail with info and status', function() {
       expect(info).to.be.an.object;
       expect(info.message).to.equal('Something is wrong with this request');
       expect(status).to.equal(400);
     });
   });
-  
+
 });

--- a/test/strategy.options.test.js
+++ b/test/strategy.options.test.js
@@ -8,7 +8,7 @@ var chai = require('chai')
 describe('Strategy', function() {
 
   describe('handling a request without a body, but no username and password, with message option to authenticate', function() {
-    var strategy = new Strategy(function(username, password, done) {
+    var strategy = new Strategy(function() {
       throw new Error('should not be called');
     });
 


### PR DESCRIPTION
I'm using passport from Geddy and there is no `req.body` / `req.query`. So I want an option to specify params.
