### PR TITLE
Define main entry module to be a js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "url": "http://www.opensource.org/licenses/MIT"
     }
   ],
-  "main": "./lib",
+  "main": "./lib/index.js",
   "dependencies": {
     "passport-strategy": "1.x.x"
   },


### PR DESCRIPTION
Define "main" to be a js module instead of a directory to enable certain tools (madge) to understand them. This is also how npm specification defines the data type: https://docs.npmjs.com/files/package.json