### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,7 @@
   "bugs": {
     "url": "http://github.com/jaredhanson/passport-local/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "./lib",
   "dependencies": {
     "passport-strategy": "1.x.x"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/