### PR TITLE
fix for restify (closes #48)

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -68,8 +68,8 @@ util.inherits(Strategy, passport.Strategy);
  */
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
-  var username = lookup(req.body, this._usernameField) || lookup(req.query, this._usernameField);
-  var password = lookup(req.body, this._passwordField) || lookup(req.query, this._passwordField);
+  var username = lookup(req.params, this._usernameField) || lookup(req.query, this._usernameField);
+  var password = lookup(req.params, this._passwordField) || lookup(req.query, this._passwordField);
   
   if (!username || !password) {
     return this.fail({ message: options.badRequestMessage || 'Missing credentials' }, 400);

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -68,8 +68,8 @@ util.inherits(Strategy, passport.Strategy);
  */
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
-  var username = lookup(req.params, this._usernameField) || lookup(req.query, this._usernameField);
-  var password = lookup(req.params, this._passwordField) || lookup(req.query, this._passwordField);
+  var username = lookup(req.params, this._usernameField) || lookup(req.body, this._usernameField) || lookup(req.query, this._usernameField);
+  var password = lookup(req.params, this._passwordField) || lookup(req.body, this._passwordField) || lookup(req.query, this._passwordField);
   
   if (!username || !password) {
     return this.fail({ message: options.badRequestMessage || 'Missing credentials' }, 400);


### PR DESCRIPTION
Restify uses req.params instead of req.body for POSTed values.
Express (with connect) uses req.body for this. 
Simply checking all 3 places (req.params, req.body, req.query) works for both frameworks, which is what this PR does (I saw PR #55 but that's wrong).

Docs on restify: 
http://mcavage.me/node-restify
and especially:
http://mcavage.me/node-restify/#bodyparser for the body parser and
http://mcavage.me/node-restify/#request-api for the req/res methods in restify.