### PR TITLE
Remove early auth error when no user or pass

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -70,11 +70,7 @@ Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var username = lookup(req.body, this._usernameField) || lookup(req.query, this._usernameField);
   var password = lookup(req.body, this._passwordField) || lookup(req.query, this._passwordField);
-  
-  if (!username || !password) {
-    return this.fail({ message: options.badRequestMessage || 'Missing credentials' }, 400);
-  }
-  
+
   var self = this;
   
   function verified(err, user, info) {


### PR DESCRIPTION
When not adding a user and pass, there is a specific error being sent. But this case is already handled by the verify callback, and it is easier and more natural to send a prettier error response to the end-user if there is no special handling of the case where user and password are not provided.