### PR TITLE
Remove mention of non-existent "session" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,12 @@ differently, options are available to change the defaults.
 
     passport.use(new LocalStrategy({
         usernameField: 'email',
-        passwordField: 'passwd',
-        session: false
+        passwordField: 'passwd'
       },
       function(username, password, done) {
         // ...
       }
     ));
-
-When session support is not necessary, it can be safely disabled by
-setting the `session` option to false.
 
 The verify callback can be supplied with the `request` object by setting
 the `passReqToCallback` option to true, and changing callback arguments
@@ -80,8 +76,7 @@ accordingly.
     passport.use(new LocalStrategy({
         usernameField: 'email',
         passwordField: 'passwd',
-        passReqToCallback: true,
-        session: false
+        passReqToCallback: true
       },
       function(req, username, password, done) {
         // request object is now first argument


### PR DESCRIPTION
The README makes some references to an option called `"session"` that were added in commit https://github.com/jaredhanson/passport-local/commit/06d290bf07c5cfcff1ef72cba8edc93bc6ca9cbc

The codebase does not contain any such option today, nor did it at the time of that commit (i.e. if you look at https://github.com/jaredhanson/passport-local/tree/06d290bf07c5cfcff1ef72cba8edc93bc6ca9cbc ).

This was confusing for me... probably for others as well.