### PR TITLE
don't treat blank username or password as missing

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -3,7 +3,8 @@
  */
 var passport = require('passport-strategy')
   , util = require('util')
-  , lookup = require('./utils').lookup;
+  , lookup = require('./utils').lookup
+  , coalesce = require('./utils').coalesce;
 
 
 /**
@@ -68,10 +69,10 @@ util.inherits(Strategy, passport.Strategy);
  */
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
-  var username = lookup(req.body, this._usernameField) || lookup(req.query, this._usernameField);
-  var password = lookup(req.body, this._passwordField) || lookup(req.query, this._passwordField);
-  
-  if (!username || !password) {
+  var username = coalesce(lookup(req.body, this._usernameField), lookup(req.query, this._usernameField));
+  var password = coalesce(lookup(req.body, this._passwordField), lookup(req.query, this._passwordField));
+
+  if (username === null || password === null) {
     return this.fail({ message: options.badRequestMessage || 'Missing credentials' }, 400);
   }
   

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,3 +9,13 @@ exports.lookup = function(obj, field) {
   }
   return null;
 };
+
+exports.coalesce = function() {
+    var len = arguments.length;
+    for (var i=0; i<len; i++) {
+        if (arguments[i] !== null && arguments[i] !== undefined) {
+            return arguments[i];
+        }
+    }
+    return null;
+};

--- a/test/strategy.normal.test.js
+++ b/test/strategy.normal.test.js
@@ -187,5 +187,42 @@ describe('Strategy', function() {
       expect(status).to.equal(400);
     });
   });
-  
+
+  describe('handling a with a blank username and password', function() {
+    var strategy = new Strategy(function(username, password, done) {
+      if (username == '' && password == '') {
+        return done(null, { id: '1234' }, { scope: 'read' });
+      }
+      return done(null, false);
+    });
+
+    var user
+      , info;
+
+    before(function(done) {
+      chai.passport(strategy)
+        .success(function(u, i) {
+          user = u;
+          info = i;
+          done();
+        })
+        .req(function(req) {
+          req.body = {};
+          req.body.username = '';
+          req.body.password = '';
+        })
+        .authenticate();
+    });
+
+    it('should supply user', function() {
+      expect(user).to.be.an.object;
+      expect(user.id).to.equal('1234');
+    });
+
+    it('should supply info', function() {
+      expect(info).to.be.an.object;
+      expect(info.scope).to.equal('read');
+    });
+  });
+
 });


### PR DESCRIPTION
My use case involves users with blank passwords, and I've run into apps where blank usernames are allowed. passport-local treats these as invalid requests. 

Regardless whether blank usernames or passwords are a good idea, it seems that it should be up to the verifier or some other system to determine whether this is valid, not passport-local. If a blank string is provided, it shouldn't be treated as a missing field.