### PR TITLE
Made strategy name an option.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -50,7 +50,7 @@ function Strategy(options, verify) {
   this._passwordField = options.passwordField || 'password';
   
   passport.Strategy.call(this);
-  this.name = 'local';
+  this.name = options.name || 'local';
   this._verify = verify;
   this._passReqToCallback = options.passReqToCallback;
 }

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -5,10 +5,15 @@ var Strategy = require('../lib/strategy');
 
 describe('Strategy', function() {
     
-  var strategy = new Strategy(function(){});
+  var strategy = new Strategy(function(){}),
+      other_strategy = new Strategy({name: 'other'}, function () {});
     
-  it('should be named local', function() {
+  it('should be named local by default', function() {
     expect(strategy.name).to.equal('local');
+  });
+
+  it('should be named other', function() {
+      expect(other_strategy.name).to.equal('other');
   });
   
   it('should throw if constructed without a verify callback', function() {


### PR DESCRIPTION
Allows for multiple local strategies.

In my case, I've created one username/password strategy, and one username/email token strategy (passwordless).