### PR TITLE
clarify body-parser and LocalStrategy in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ password.  The strategy requires a `verify` callback, which accepts these
 credentials and calls `done` providing a user.
 
 ```js
+passport = require('passport');
+LocalStrategy = require('passport-local').Strategy;
+
 passport.use(new LocalStrategy(
   function(username, password, done) {
     User.findOne({ username: username }, function (err, user) {
@@ -92,12 +95,17 @@ accordingly.
 #### Authenticate Requests
 
 Use `passport.authenticate()`, specifying the `'local'` strategy, to
-authenticate requests.
+authenticate requests. It searches for fields in the query string and
+`req.body`, so ensure body parsers are in place if these fields are
+sent in the body.
 
 For example, as route middleware in an [Express](http://expressjs.com/)
 application:
 
 ```js
+app.use(require('body-parser').urlencoded({ extended: true }));
+app.use(passport.initialize());
+
 app.post('/login', 
   passport.authenticate('local', { failureRedirect: '/login' }),
   function(req, res) {


### PR DESCRIPTION
This PR adds a bit more detail to the readme around two major stumbling blocks for new users:

* It's unclear where `LocalStrategy` in the first code example comes from
* It's unclear that `body-parser` is required for fields to be available in `req.body`, where `passport-local` expects them.

I haven't seen anyone complaining about the former, but it was a bit confusing for me and easy enough to fix as part of this PR.

There's plenty of examples of people having issues with the latter:
* https://github.com/jaredhanson/passport-local/issues/143
* https://github.com/jaredhanson/passport-local/issues/129
* http://stackoverflow.com/questions/18690354/passport-local-strategy-not-getting-called
* http://stackoverflow.com/questions/24688142/nodejs-passport-authenticate-callback-not-being-called-with-no-errors
