### PR TITLE
Move misplaced `}` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ passport.use(new LocalStrategy(
 
 ##### Available Options
 
-This strategy takes an optional options hash before the function, e.g. `new LocalStrategy({/* options */, callback})`.
+This strategy takes an optional options hash before the function, e.g. `new LocalStrategy({/* options */}, callback)`.
 
 The available options are:
 
@@ -98,7 +98,7 @@ For example, as route middleware in an [Express](http://expressjs.com/)
 application:
 
 ```js
-app.post('/login', 
+app.post('/login',
   passport.authenticate('local', { failureRedirect: '/login' }),
   function(req, res) {
     res.redirect('/');


### PR DESCRIPTION
Also, remove trailing whitespace in README.md.