### PR TITLE
Small tweak to the README so that the code syntax has js highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,17 @@ By default, `LocalStrategy` expects to find credentials in parameters
 named username and password. If your site prefers to name these fields
 differently, options are available to change the defaults.
 
-    passport.use(new LocalStrategy({
-        usernameField: 'email',
-        passwordField: 'passwd',
-        session: false
-      },
-      function(username, password, done) {
-        // ...
-      }
-    ));
+```js
+passport.use(new LocalStrategy({
+    usernameField: 'email',
+    passwordField: 'passwd',
+    session: false
+  },
+  function(username, password, done) {
+    // ...
+  }
+));
+```
 
 When session support is not necessary, it can be safely disabled by
 setting the `session` option to false.
@@ -83,17 +85,19 @@ The verify callback can be supplied with the `request` object by setting
 the `passReqToCallback` option to true, and changing callback arguments
 accordingly.
 
-    passport.use(new LocalStrategy({
-        usernameField: 'email',
-        passwordField: 'passwd',
-        passReqToCallback: true,
-        session: false
-      },
-      function(req, username, password, done) {
-        // request object is now first argument
-        // ...
-      }
-    ));
+```js
+passport.use(new LocalStrategy({
+    usernameField: 'email',
+    passwordField: 'passwd',
+    passReqToCallback: true,
+    session: false
+  },
+  function(req, username, password, done) {
+    // request object is now first argument
+    // ...
+  }
+));
+```
 
 #### Authenticate Requests
 


### PR DESCRIPTION
Just a small tweak to the README so that the code syntax has js highlighting. Not ground breaking stuff here but I find that the color helps my brain 😄 

** READ THIS FIRST! **

#### Are you implementing a new feature?

> Nope, just an update to the README

Requests for new features should first be discussed on the [developer forum](https://github.com/passport/develop).
This allows the community to gather feedback and assess whether or not there is
an existing way to achieve the desired functionality.

If it is determined that a new feature needs to be implemented, include a link
to the relevant discussion along with the pull request.

#### Is this a security patch?

> Nope

Do not open pull requests that might have security implications.  Potential
security vulnerabilities should be reported privately to jaredhanson@gmail.com.
Once any vulerabilities have been repaired, the details will be disclosed
publicly in a responsible manner.  This also allows time for coordinating with
affected parties in order to mitigate negative consequences.


If neither of the above two scenarios apply to your situation, you should open
a pull request.  Delete this paragraph and the text above, and fill in the
information requested below.

<!-- Provide a brief summary of the request in the title field above. -->

<!-- Provide a detailed description of your use case, including as much -->
<!-- detail as possible about what you are trying to accomplish and why. -->
<!-- If this patch closes an open issue, include a reference to the issue -->
<!-- number. -->

### Checklist

<!-- Place an `x` in the boxes that apply.  If you are unsure, please ask and -->
<!-- we will help. -->

> Will be omitting the below as there are no code changes

- [ ] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport-local/blob/master/CONTRIBUTING.md) guidelines.
- [ ] I have added test cases which verify the correct operation of this feature or patch.
- [x] I have added documentation pertaining to this feature or patch.
- [ ] The automated test suite (`$ make test`) executes successfully.
- [ ] The automated code linting (`$ make lint`) executes successfully.
