### PR TITLE
revised strategy to allow the credentials to be located anywhere in t…

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,101 @@
+# passport-local
+
+[![Build](https://travis-ci.org/jaredhanson/passport-local.png)](https://travis-ci.org/jaredhanson/passport-local)
+[![Coverage](https://coveralls.io/repos/jaredhanson/passport-local/badge.png)](https://coveralls.io/r/jaredhanson/passport-local)
+[![Quality](https://codeclimate.com/github/jaredhanson/passport-local.png)](https://codeclimate.com/github/jaredhanson/passport-local)
+[![Dependencies](https://david-dm.org/jaredhanson/passport-local.png)](https://david-dm.org/jaredhanson/passport-local)
+[![Tips](http://img.shields.io/gittip/jaredhanson.png)](https://www.gittip.com/jaredhanson/)
+
+
+[Passport](http://passportjs.org/) strategy for authenticating with a username
+and password.
+
+This module lets you authenticate using a username and password in your Node.js
+applications.  By plugging into Passport, local authentication can be easily and
+unobtrusively integrated into any application or framework that supports
+[Connect](http://www.senchalabs.org/connect/)-style middleware, including
+[Express](http://expressjs.com/).
+
+## Install
+
+    $ npm install passport-local
+
+## Usage
+
+#### Configure Strategy
+
+The local authentication strategy authenticates users using a username and
+password.  The strategy requires a `verify` callback, which accepts these
+credentials and calls `done` providing a user.
+
+  const callbackFunction=
+      function(username, password, done) {
+        User.findOne({ username: username }, function (err, user) {
+          if (err) { return done(err); }
+          if (!user) { return done(null, false); }
+          if (!user.verifyPassword(password)) { return done(null, false); }
+          return done(null, user);
+        });
+      };
+
+    passport.use(new LocalStrategy(callbackFunction));
+    
+Or
+
+If the credentials are in the request body (reg.body.specialusernamefieldname or
+req.query.specialuserfieldname), this works...
+  
+    passport.use(new LocalStrategy({
+      usernameField: 'specialusernamefieldname',
+      passwordField: 'specialpasswordfieldname'
+      
+    },
+    callbackFunction));
+
+Or
+
+if the credentials are in any other part of the request object,
+(req.body.headers.specialusernamefieldname), you can use this...
+
+    passport.use(new LocalStrategy({
+      usernameField: 'headers.specialusernamefieldname',
+      passwordField: 'headers.specialpasswordfieldname'
+      
+    },
+    callbackFunction));
+
+This works for any part of the request object you can describe with a dotted path.
+    
+
+#### Authenticate Requests
+
+Use `passport.authenticate()`, specifying the `'local'` strategy, to
+authenticate requests.
+
+For example, as route middleware in an [Express](http://expressjs.com/)
+application:
+
+    app.post('/login', 
+      passport.authenticate('local', { failureRedirect: '/login' }),
+      function(req, res) {
+        res.redirect('/');
+      });
+
+## Examples
+
+For complete, working examples, refer to the multiple [examples](https://github.com/jaredhanson/passport-local/tree/master/examples) included.
+
+## Tests
+
+    $ npm install
+    $ npm test
+
+## Credits
+
+  - [Jared Hanson](http://github.com/jaredhanson)
+
+## License
+
+[The MIT License](http://opensource.org/licenses/MIT)
+
+Copyright (c) 2011-2014 Jared Hanson <[http://jaredhanson.net/](http://jaredhanson.net/)>

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -15,7 +15,7 @@ var passport = require('passport-strategy')
  * Applications must supply a `verify` callback which accepts `username` and
  * `password` credentials, and then calls the `done` callback supplying a
  * `user`, which should be set to `false` if the credentials are not valid.
- * If an exception occurred, `err` should be set.
+ * If an exception occured, `err` should be set.
  *
  * Optionally, `options` can be used to change the fields in which the
  * credentials are found.
@@ -70,6 +70,13 @@ Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var username = lookup(req.body, this._usernameField) || lookup(req.query, this._usernameField);
   var password = lookup(req.body, this._passwordField) || lookup(req.query, this._passwordField);
+  
+  if (!username){
+  	username = lookup(req, this._usernameField);
+  }
+  if (!password){
+  	password = lookup(req, this._passwordField);
+  }
   
   if (!username || !password) {
     return this.fail({ message: options.badRequestMessage || 'Missing credentials' }, 400);


### PR DESCRIPTION
The module's lookup() function actually accepts a dotted path as input. In the current implementation, this is applied to either the request body or query properties. It was useful to pass the credentials in the header but, since the lookup() function was applied specifically to those two properties, this strategy would not support that case.

The code was revised to, if the credentials were not found in the backward compatible case, try to get them as a reference to the req object itself, eg, lookup(req, 'headers.password');