### PR TITLE
Apply JS code style and fix indent in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,17 @@ By default, `LocalStrategy` expects to find credentials in parameters
 named username and password. If your site prefers to name these fields
 differently, options are available to change the defaults.
 
-    passport.use(new LocalStrategy({
-        usernameField: 'email',
-        passwordField: 'passwd',
-        session: false
-      },
-      function(username, password, done) {
-        // ...
-      }
-    ));
+```js
+passport.use(new LocalStrategy({
+    usernameField: 'email',
+    passwordField: 'passwd',
+    session: false
+  },
+  function(username, password, done) {
+    // ...
+  }
+));
+```
 
 When session support is not necessary, it can be safely disabled by
 setting the `session` option to false.
@@ -94,17 +96,19 @@ The verify callback can be supplied with the `request` object by setting
 the `passReqToCallback` option to true, and changing callback arguments
 accordingly.
 
-    passport.use(new LocalStrategy({
-        usernameField: 'email',
-        passwordField: 'passwd',
-        passReqToCallback: true,
-        session: false
-      },
-      function(req, username, password, done) {
-        // request object is now first argument
-        // ...
-      }
-    ));
+```js
+passport.use(new LocalStrategy({
+    usernameField: 'email',
+    passwordField: 'passwd',
+    passReqToCallback: true,
+    session: false
+  },
+  function(req, username, password, done) {
+    // request object is now first argument
+    // ...
+  }
+));
+```
 
 #### Authenticate Requests
 


### PR DESCRIPTION
Apply JavaScript code styles to Parameters section code block, and fix indent 4 spaces to 2 spaces.