### PR TITLE
Fix typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ passport.use(new LocalStrategy(
 
 ##### Available Options
 
-This strategy takes an optional options hash before the function, e.g. `new LocalStrategy({/* options */, callback})`.
+This strategy takes an optional options hash before the function, e.g. `new LocalStrategy({/* options */}, callback)`.
 
 The available options are:
 


### PR DESCRIPTION
This fixes a simple typo in the README (`}` in the wrong location) which confused me for a bit.